### PR TITLE
 Convert domain_validation_options to a list

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -82,10 +82,10 @@ resource "aws_acm_certificate" "cert_pool_domain" {
 }
 
 resource "aws_route53_record" "cert_pool_domain_validation" {
-  name    = aws_acm_certificate.cert_pool_domain.domain_validation_options.0.resource_record_name
-  type    = aws_acm_certificate.cert_pool_domain.domain_validation_options.0.resource_record_type
+  name    = tolist(aws_acm_certificate.cert_pool_domain.domain_validation_options)[0].resource_record_name
+  type    = tolist(aws_acm_certificate.cert_pool_domain.domain_validation_options)[0].resource_record_type
   zone_id = data.aws_route53_zone.main.id
-  records = [aws_acm_certificate.cert_pool_domain.domain_validation_options.0.resource_record_value]
+  records = [tolist(aws_acm_certificate.cert_pool_domain.domain_validation_options)[0].resource_record_value]
   ttl     = 60
 }
 


### PR DESCRIPTION
In the new major version of the AWS provider (v3), `domain_validation_options` is now a set (previously a list). The current version of the module will thus fail if you use the new AWS provider.

The changes introduced here align with the [official upgrade guide for AWS provider v3.0](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-3-upgrade#resource-aws_acm_certificate), and should be backwards-compatible. AWS Provider versions < 3.0 will simply convert a list to a list.